### PR TITLE
Feature: 메인화면 상품 리스트 조회 기능 추가

### DIFF
--- a/controllers/product_controller.js
+++ b/controllers/product_controller.js
@@ -1,0 +1,16 @@
+const productService = require("../services/product_service")
+
+
+const mainPageList = async (req, res) => {
+  try{
+    const dataList = await productService.mainProductList();
+    res.status(200).json({ main: dataList })
+  } catch (error){
+    console.log(error);
+    res.status(error.statusCode || 500).json({ error: error.message })
+  }
+}
+
+
+
+module.exports = { mainPageList }

--- a/controllers/user_controller.js
+++ b/controllers/user_controller.js
@@ -2,15 +2,15 @@ const userService = require('../services/user_service');
 
 
 const signUpController = async (req, res) => {
-  const { email, password, name, phone } = req.body;
+  const { email, pwd, name, phone } = req.body;
 
-  if (!(email && password && name && phone)) {
+  if (!(email && pwd && name && phone)) {
     res.status(400).json({ error: 'INPUT_ERROR' });
     return;
   }
 
   try {
-    await userService.signUpService(email, password, name, phone );
+    await userService.signUpService(email, pwd, name, phone );
     res.status(201).json({ message: 'USER_CREATED' });
   } catch (error) {
     console.log(error);
@@ -19,15 +19,15 @@ const signUpController = async (req, res) => {
 }
 
 const logInController = async (req, res) => {
-  const { id, pw } = req.body;
+  const { email, pwd } = req.body;
 
-  if(!(id && pw)) {
+  if(!(email && pwd)) {
     res.status(400).json({ error: "INPUT_ERROR"})
     return;
   }
 
   try{
-    const resData = await userService.logInService(id, pw)
+    const resData = await userService.logInService(email, pwd)
     res.status(201).json( resData )
   } catch (error) {
     console.log(error);

--- a/models/product_dao.js
+++ b/models/product_dao.js
@@ -1,0 +1,89 @@
+const myDataSource = require('./init');
+
+const getProductListInMonth = async () => {
+  const queryRes = await myDataSource.query(`
+  SELECT 
+    p.id as product_id,
+    p.name as product_name,
+    p.thumbnail_image as image,
+    CONCAT(p.sale_rate, "%") as sale_rate,
+    CASE
+      WHEN p.sale_rate IS null 
+      THEN REPLACE(p.origin_price, '.', ',')
+      ELSE FORMAT(FLOOR((1-(p.sale_rate * 0.01)) * p.origin_price)*1000, 0)
+    END as price,
+    s.name as shop,
+    CASE
+      WHEN s.delivery_fee IS null AND s.delivery_condition IS null
+      THEN null
+      ELSE 1
+    END as delivery_type,
+    c.name as category,
+    r.average,
+    r.review_count
+  FROM products p
+  LEFT JOIN 
+    (SELECT product_id, TRUNCATE(AVG(rate), 1) as average, COUNT(id) as review_count 
+    FROM reviews
+    GROUP BY product_id) as r
+  ON p.id = r.product_id
+  JOIN category c
+  ON p.category_id = c.id
+  JOIN sellers s
+  ON p.seller_id = s.id
+  WHERE p.created_at BETWEEN DATE_ADD(NOW(), INTERVAL -1 MONTH ) AND NOW()
+  ORDER BY p.created_at
+  LIMIT 16;
+  `)
+
+  return queryRes;
+}
+
+const getProductListByLiked = async () => {
+  const queryRes = await myDataSource.query(`
+  SELECT 
+    p.id as product_id,
+    p.name as product_name,
+    p.thumbnail_image as image,
+    CONCAT(p.sale_rate, "%") as sale_rate,
+    CASE
+      WHEN p.sale_rate IS null 
+      THEN REPLACE(p.origin_price, '.', ',')
+      ELSE FORMAT(FLOOR((1-(p.sale_rate * 0.01)) * p.origin_price)*1000, 0)
+    END as price,
+    s.name as shop,CASE
+    WHEN s.delivery_fee IS null AND s.delivery_condition IS null
+      THEN null
+      ELSE 1
+    END as delivery_type,
+    c.name as category,
+    r.average,
+    r.review_count
+  FROM products p
+  LEFT JOIN 
+    (SELECT product_id, TRUNCATE(AVG(rate), 1) as average, COUNT(id) as review_count
+    FROM reviews
+    GROUP BY product_id) as r
+  ON p.id = r.product_id
+  LEFT JOIN
+    (SELECT product_id, COUNT(product_id) as count
+    FROM product_liked
+    GROUP BY product_id) as p_l
+  ON p.id = p_l.product_id
+  JOIN category c
+  ON p.category_id = c.id
+  JOIN sellers s
+  ON p.seller_id = s.id
+  ORDER BY p_l.count DESC
+  LIMIT 16;
+  `)
+
+  return queryRes;
+}
+
+
+
+module.exports = { 
+  getProductListInMonth,
+  getProductListByLiked
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,4 +8,7 @@ router.get('/ping', (_, res) => { res.send('pong') });
 
 router.use('/users', userRouter);
 
+// 디자인 마켓
+router.use('', productRouter);
+
 module.exports = router;

--- a/routes/product_router.js
+++ b/routes/product_router.js
@@ -1,0 +1,9 @@
+const express = require("express")
+const productController = require("../controllers/product_controller")
+const router = express.Router()
+
+
+// 디자인 마켓
+router.get('/',productController.mainPageList)
+
+module.exports = router;

--- a/services/product_service.js
+++ b/services/product_service.js
@@ -1,0 +1,11 @@
+const productDao = require('../models/product_dao');
+
+const mainProductList = async () => {
+  const list = {}
+  list.new = await productDao.getProductListInMonth();
+  list.popular = await productDao.getProductListByLiked();  
+  return list;
+}
+
+
+module.exports = { mainProductList }

--- a/services/user_service.js
+++ b/services/user_service.js
@@ -20,28 +20,27 @@ const signUpService = async (email, password, name, phone) => {
 }
 
 const logInService = async (email, password) => {
-    const userEmailPw = await userDao.getUserByEmail(email);
-    if (!userEmailPw) {
-      const error = new Error('USER_NOT_EXISTE');
-      error.statusCode = 400;
-      throw error;
-    }
-  
-    const isPasswordCorrect = bcrypt.compareSync(password, userEmailPw.password);
-  
-    if (!isPasswordCorrect) {
-      const error = new Error('PASSWORD_INCORRECTED');
-      error.statusCode = 400;
-      throw error;
-    } else if (isPasswordCorrect) {
-      const token = jwt.sign({ userEmail: userEmailPw.email }, SECRET_KEY, {
-        expiresIn: '1h' });
-  
-      const user = {};
-      user["name"] = userEmailPw["name"]
-      user["token"] = token
-      return user;
-    }
+  const userEmailPw = await userDao.getUserByEmail(email);
+  if (!userEmailPw) {
+    const error = new Error('USER_NOT_EXISTE');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const isPasswordCorrect = bcrypt.compareSync(password, userEmailPw.password);
+
+  if (!isPasswordCorrect) {
+    const error = new Error('PASSWORD_INCORRECTED');
+    error.statusCode = 400;
+    throw error;
+  } else if (isPasswordCorrect) {
+    const token = jwt.sign({ userEmail: userEmailPw.email }, SECRET_KEY);
+    //  {  expiresIn: '1h' }
+    const user = {};
+    user["name"] = userEmailPw["name"]
+    user["token"] = token
+    return user;
+  }
 }
 
 module.exports = { signUpService, logInService }


### PR DESCRIPTION
메인화면 상품 리스트 조회 기능 추가
  - 한 달 내 등록된 신상품 리스트 조회
  - 전체 상품에서 좋아요 수가 많은 순으로 상품 리스트 조회
  - 상품 카테고리, 이름, 가격, 할인율, 이미지 외 상품에 등록된 리뷰 수, 평균 별점, 판매자, 무료배송 정보도 같이 조회

Issue: #8

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 메인 화면에 필요한 상품 리스트 조회하는 기능 추가

<br />

## :: 구현 사항 설명
1. 상품 리스트 조회
- 한 달 내 등록된 신상품을 등록순으로 조회(갯수 limit)
- 전체 제품에서 눌린 좋아요 수를 기준으로 많은 순서로 상품 리스트를 조회(갯수 limit)
- 쿼리문 내에 JOIN, 조건문, 서브쿼리, FORMAT, FLOOR, CONCAT 등을 활용하여 각각 조회한 두 목록을 합쳐서 전달

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.
